### PR TITLE
Fix HTML entities appearing in image captions

### DIFF
--- a/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/ArticleFragment.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/ArticleFragment.java
@@ -632,7 +632,7 @@ public class ArticleFragment extends Fragment implements TextInputAlertCallback 
 		MyTagNodeVisitor tnv = new MyTagNodeVisitor(extra);
 		node.traverse(tnv);
 
-		return tnv.alt;
+		return Html.fromHtml(tnv.alt).toString();
 	}
 
 	/**


### PR DESCRIPTION
Apparently the method getAttributeByName used in MyTagNodeVisitor doesn't return a decoded string. This should fix that.