### PR TITLE
Mark some strings as non-translatable

### DIFF
--- a/ttrssreader/src/main/res/values-de/strings.xml
+++ b/ttrssreader/src/main/res/values-de/strings.xml
@@ -243,8 +243,6 @@
 	<string name="About.project_hint">Informationen zur Entwicklung, Changelog etc.</string>
 	<string name="About.twitter">Twitter</string>
 	<string name="About.twitter_hint">Kontaktieren Sie mich auf Twitter.</string>
-	<string name="About.twitter_acc">http://twitter.com/nilsbraden</string>
-	<string name="About.mail">ttrss@nilsbraden.de</string>
 	<string name="About.feedback">Feedback</string>
 	<string name="About.feedback_hint">Berichte Fehler, Anfragen für neue Funktionen…</string>
 	<string name="Utils.DownloadFinishedTitle">Download</string>

--- a/ttrssreader/src/main/res/values-es/strings.xml
+++ b/ttrssreader/src/main/res/values-es/strings.xml
@@ -140,8 +140,6 @@
 	<string name="About.project_hint">Información del desarrollo, Cambios, etc.</string>
 	<string name="About.twitter">Twitter</string>
 	<string name="About.twitter_hint">Contacte me en twitter.</string>
-	<string name="About.twitter_acc">http://twitter.com/nilsbraden</string>
-	<string name="About.mail">ttrss@nilsbraden.de</string>
 	<string name="About.feedback">Feedback</string>
 	<string name="About.feedback_hint">Informe fallos, peticiones…</string>
 	<string name="Utils.DownloadFinishedTitle">Descargar</string>

--- a/ttrssreader/src/main/res/values/strings.xml
+++ b/ttrssreader/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
 	<string name="Preferences.ResetCache">Reset ImageCache</string>
 	<string name="Preferences.Btn">Preferences</string>
 	<string name="Changelog.Title">Changelog</string>
-	<string name="DonateUrl">https://github.com/nilsbraden/ttrss-reader-fork/wiki/Donations</string>
+	<string name="DonateUrl" translatable="false">https://github.com/nilsbraden/ttrss-reader-fork/wiki/Donations</string>
 	<string name="Welcome.Title">Welcome</string>
 	<string name="Welcome.Message">Welcome to TTRSS-Reader!\n\nPlease note that this Reader only works with a \"Tiny Tiny RSS\" Server.\n\nIf this is the first time you started TTRSS-Reader you should set your Serverlocation and User-Settings. Press "Preferences" to proceed.</string>
 	<string name="Check.Crash">A crashreport was saved, do you want to send it to the developer by mail?</string>
@@ -38,7 +38,7 @@
 	<string name="AboutActivity.DonateBtn">Want to Donate?</string>
 	<string name="AboutActivity.VersionText">Version:</string>
 	<string name="AboutActivity.VersionCodeText">Version-Code:</string>
-	<string name="AboutActivity.UrlTextValue">https://github.com/nilsbraden/ttrss-reader-fork</string>
+	<string name="AboutActivity.UrlTextValue" translatable="false">https://github.com/nilsbraden/ttrss-reader-fork</string>
 	<string name="AboutActivity.LicenseText">License:</string>
 	<string name="AboutActivity.LicenseTextValue">GPL v3</string>
 	<string name="AboutActivity.LastSyncText">Last sync:</string>
@@ -253,8 +253,8 @@
 	<string name="About.project_hint">Information on Development, Changelog etc.</string>
 	<string name="About.twitter">Twitter</string>
 	<string name="About.twitter_hint">Contact me on twitter.</string>
-	<string name="About.twitter_acc">http://twitter.com/nilsbraden</string>
-	<string name="About.mail">ttrss@nilsbraden.de</string>
+	<string name="About.twitter_acc" translatable="false">http://twitter.com/nilsbraden</string>
+	<string name="About.mail" translatable="false">ttrss@nilsbraden.de</string>
 	<string name="About.feedback">Feedback</string>
 	<string name="About.feedback_hint">Report bugs, request features …</string>
 	<string name="Utils.DownloadFinishedTitle">Download</string>


### PR DESCRIPTION
Set 'translatable="false"' to URLs and email addresses: http://tools.android.com/recent/non-translatablestrings
Duplicate strings found in other languages are removed.