### PR TITLE
Mark as unread

### DIFF
--- a/ttrssreader/src/main/java/org/ttrssreader/gui/FeedHeadlineActivity.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/gui/FeedHeadlineActivity.java
@@ -345,8 +345,7 @@ public class FeedHeadlineActivity extends MenuActivity {
 		if (!Controller.isTablet) ft.addToBackStack(null);
 		setAnimationForDirection(ft, direction);
 		ft.setTransition(FragmentTransaction.TRANSIT_NONE);
-		if (direction == 0) ft.add(R.id.frame_sub, articleFragment, ArticleFragment.FRAGMENT).commit();
-		else ft.replace(R.id.frame_sub, articleFragment, ArticleFragment.FRAGMENT).commit();
+		ft.replace(R.id.frame_sub, articleFragment, ArticleFragment.FRAGMENT).commit();
 
 		// Check if a next feed in this direction exists
 		if (direction != 0) {

--- a/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/ArticleFragment.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/ArticleFragment.java
@@ -283,10 +283,11 @@ public class ArticleFragment extends Fragment implements TextInputAlertCallback 
 				// you set it to "unread" in the meantime.
 				if (article.isUnread) {
 					article.isUnread = false;
-					markedRead = true;
 					new Updater(null, new ArticleReadStateUpdater(article, 0))
 							.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
 				}
+				// Regardless of whether we did it, the article has been marked read.
+				markedRead = true;
 
 				cachedImages = getCachedImagesJS(article.id);
 


### PR DESCRIPTION
Attempt to fix problems observed in #278 with mark as unread.  I'm a bit uncertain about these changes, because they mostly just remove code.  In particular, I'm not sure what the code that reads `markedRead` is actually for.  (In general, I'm suspicious about using asynchronous tasks for changing the read flag because I'm worried that it could introduce races.)  That said, they did work in some quick tests and I'm about to put a copy on my tablet and see how it goes.