### PR TITLE
Use https if downloadurl has a prefix/scheme of just "//"

### DIFF
--- a/ttrssreader/src/main/java/org/ttrssreader/utils/FileUtils.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/utils/FileUtils.java
@@ -90,6 +90,10 @@ public class FileUtils {
 		InputStream is = null;
 
 		try (FileOutputStream fos = new FileOutputStream(file)) {
+			// In case where http and https is supported we might get just // as URL prefix, so we use a secure default...
+			if(downloadUrl.startsWith("//"))
+				downloadUrl = "https:" + downloadUrl;
+
 			URL url = new URL(downloadUrl);
 			URLConnection connection = Controller.getInstance().openConnection(url);
 


### PR DESCRIPTION
Fixes issue 301. We might just get a "//" as prefix, e.g. when both, HTTP and
HTTPs is possible. In this case we use a sane default, https: