### PR TITLE
Add new GUID field to the Article POJO to match latest TT-RSS API.

### DIFF
--- a/ttrssreader/src/main/java/org/ttrssreader/model/pojos/Article.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/model/pojos/Article.java
@@ -25,6 +25,7 @@ import java.util.Set;
 public class Article implements Comparable<Article> {
 
 	public int id;
+	public String guid;
 	public String title;
 	public int feedId;
 	public volatile boolean isUnread;
@@ -61,7 +62,7 @@ public class Article implements Comparable<Article> {
 	}
 
 	public enum ArticleField {
-		id, title, unread, updated, feed_id, content, link, comments, attachments, marked, published, labels,
+		id, guid, title, unread, updated, feed_id, content, link, comments, attachments, marked, published, labels,
 		is_updated, tags, feed_title, comments_count, comments_link, always_display_attachments, author, score, lang,
 		note
 	}

--- a/ttrssreader/src/main/java/org/ttrssreader/net/JSONConnector.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/net/JSONConnector.java
@@ -591,13 +591,16 @@ public class JSONConnector {
 			}
 
 			String name = reader.nextName();
-			Article.ArticleField field = Article.ArticleField.valueOf(name);
 
 			try {
+				Article.ArticleField field = Article.ArticleField.valueOf(name);
 
 				switch (field) {
 					case id:
 						a.id = reader.nextInt();
+						break;
+					case guid:
+						a.guid = reader.nextString();
 						break;
 					case title:
 						a.title = reader.nextString();
@@ -653,7 +656,7 @@ public class JSONConnector {
 				if (filter != null) skipObject = filter.omitArticle(field, a);
 
 			} catch (IllegalArgumentException | IOException e) {
-				Log.w(TAG, "Result contained illegal value for entry \"" + field + "\".");
+				Log.w(TAG, "Result contained illegal value for entry \"" + name + "\".");
 				reader.skipValue();
 			}
 		}


### PR DESCRIPTION
Fixes #319.

The latest TT-RSS API adds a new `guid` field to the `Article`s returned in the API, which was causing an exception to be thrown during refresh of the server. I've added the missing field and verified that articles once again show up in the app with this patch.

I'm not too sure of the new GUID field's semantics, i.e. whether it is reliably filled for all articles on a compatible server. If so, perhaps the POJO should be modified further to compare and hash against the `guid` rather than `id` field.