### PR TITLE
Allow User-added-CAs in Android 7.

### DIFF
--- a/ttrssreader/src/main/AndroidManifest.xml
+++ b/ttrssreader/src/main/AndroidManifest.xml
@@ -58,7 +58,8 @@
         android:hardwareAccelerated="true"
         android:icon="@drawable/icon"
         android:label="@string/ApplicationName"
-        android:supportsRtl="true">
+        android:supportsRtl="true"
+        android:networkSecurityConfig="@xml/network_security_config">
         <provider
             android:name=".model.ListContentProvider"
             android:authorities="org.ttrssreader"

--- a/ttrssreader/src/main/res/xml/network_security_config.xml
+++ b/ttrssreader/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>
+


### PR DESCRIPTION
See:
	- https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html
	- https://developer.android.com/training/articles/security-config.html