### PR TITLE
issue #146 - support ssl client certificates

### DIFF
--- a/ttrssreader/src/main/java/org/ttrssreader/controllers/Controller.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/controllers/Controller.java
@@ -454,6 +454,14 @@ public class Controller extends Constants implements OnSharedPreferenceChangeLis
 		else return prefs.getString(KEYSTORE_PASSWORD, EMPTY);
 	}
 
+	public String getClientCertificateAlias() {
+		// Load from Wifi-Preferences:
+		String key = getStringWithSSID(CLIENT_CERTIFICATE, getCurrentSSID(wifiManager), wifibasedPrefsEnabled());
+
+		if (prefs.contains(key)) return prefs.getString(key, EMPTY);
+		else return prefs.getString(KEYSTORE_PASSWORD, EMPTY);
+	}
+
 	public boolean urlNeedsAuthentication(URL url) {
 		if (!this.useHttpAuth()) return false;
 

--- a/ttrssreader/src/main/java/org/ttrssreader/net/JSONConnector.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/net/JSONConnector.java
@@ -37,6 +37,7 @@ import org.ttrssreader.model.pojos.Article;
 import org.ttrssreader.model.pojos.Category;
 import org.ttrssreader.model.pojos.Feed;
 import org.ttrssreader.model.pojos.Label;
+import org.ttrssreader.utils.KeyChainKeyManager;
 import org.ttrssreader.utils.StringSupport;
 import org.ttrssreader.utils.Utils;
 
@@ -57,6 +58,9 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
@@ -179,6 +183,14 @@ public class JSONConnector {
 			// HTTP-Basic Authentication
 			if (base64NameAndPw != null)
 				con.setRequestProperty("Authorization", "Basic " + base64NameAndPw);
+
+			// HTTPS client certificate
+			if (con instanceof HttpsURLConnection) {
+				KeyManager km = new KeyChainKeyManager();
+				SSLContext sslContext = SSLContext.getInstance("TLS");
+				sslContext.init(new KeyManager[]{km}, null, null);
+				((HttpsURLConnection) con).setSSLSocketFactory(sslContext.getSocketFactory());
+			}
 
 			// Add POST data
 			con.getOutputStream().write(outputBytes);

--- a/ttrssreader/src/main/java/org/ttrssreader/preferences/CertificatePreference.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/preferences/CertificatePreference.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2015, Nils Braden
+ *
+ * This file is part of ttrss-reader-fork. This program is free software; you
+ * can redistribute it and/or modify it under the terms of the GNU
+ * General Public License as published by the Free Software Foundation;
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details. You should have received a
+ * copy of the GNU General Public License along with this program; If
+ * not, see http://www.gnu.org/licenses/.
+ */
+
+package org.ttrssreader.preferences;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.net.Uri;
+import android.preference.Preference;
+import android.security.KeyChain;
+import android.security.KeyChainAliasCallback;
+import android.util.AttributeSet;
+import android.util.Log;
+
+import org.ttrssreader.controllers.Controller;
+
+/** Preference that uses the Android certificate selection dialog to select and authorize a cert */
+public class CertificatePreference extends Preference {
+	private static final String TAG = CertificatePreference.class.getSimpleName();
+
+	public CertificatePreference(Context context) {
+		super(context);
+	}
+
+	public CertificatePreference(Context context, AttributeSet attrs) {
+		super(context, attrs);
+	}
+
+	public CertificatePreference(Context context, AttributeSet attrs, int defStyle) { super(context, attrs, defStyle); }
+
+	@Override
+	protected void onClick() {
+		// have the Android cert selection dialog show the connection url
+		Uri connectionUri = null;
+		String connectionUrl = Controller.getInstance().hostname();
+		try {
+			connectionUri = Uri.parse(connectionUrl);
+		} catch (Exception e) {
+			Log.w(TAG, "could not parse " + connectionUrl, e);
+		}
+		// also have it preselect the current cert if any
+		String preselectCert = getPersistedString(null);
+		Log.d(TAG, "preselected was " + preselectCert);
+
+		// show the dialog
+		KeyChainAliasCallbackImpl response = new KeyChainAliasCallbackImpl();
+		KeyChain.choosePrivateKeyAlias(
+			getActivity(getContext()), response,
+			null, null, connectionUri, preselectCert);
+	}
+
+	private static Activity getActivity(Context context) {
+		if (context instanceof Activity) return (Activity) context;
+		if (context instanceof ContextWrapper) return getActivity(((ContextWrapper)context).getBaseContext());
+		return null;
+	}
+
+	/** Callback from the Android cert selection dialog, to inform us of what has been selected */
+	class KeyChainAliasCallbackImpl implements KeyChainAliasCallback {
+		@Override
+		public void alias(String alias) {
+			persistString(alias);
+		}
+	}
+}

--- a/ttrssreader/src/main/java/org/ttrssreader/preferences/Constants.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/preferences/Constants.java
@@ -41,6 +41,7 @@ public class Constants {
 	public static final String TRUST_ALL_HOSTS = "ConnectionTrustHostsPreference";
 	public static final String USE_KEYSTORE = "ConnectionUseKeystorePreference";
 	public static final String KEYSTORE_PASSWORD = "ConnectionKeystorePasswordPreference";
+	public static final String CLIENT_CERTIFICATE = "ConnectionClientCertificatePreference";
 	public static final String USE_OF_A_LAZY_SERVER = "ConnectionLazyServerPreference";
 	public static final String IGNORE_UNSAFE_CONNECTION_ERROR = "IgnoreUnsafeConnectionError";
 	// Connection Default Values

--- a/ttrssreader/src/main/java/org/ttrssreader/utils/KeyChainKeyManager.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/utils/KeyChainKeyManager.java
@@ -1,0 +1,62 @@
+package org.ttrssreader.utils;
+
+import android.security.KeyChain;
+import android.security.KeyChainException;
+import android.util.Log;
+
+import org.ttrssreader.MyApplication;
+import org.ttrssreader.controllers.Controller;
+
+import java.net.Socket;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.X509ExtendedKeyManager;
+
+/**
+ * A KeyManager that retrieves its keys from the Android credential storage.
+ * @see KeyChain
+ */
+public class KeyChainKeyManager extends X509ExtendedKeyManager {
+	/** Returns the currently selected certificate alias from the app preferences */
+	@Override
+	public String chooseClientAlias(String[] strings, Principal[] principals, Socket socket) {
+		return Controller.getInstance().getClientCertificateAlias();
+	}
+
+	/**
+	 * Retrieves the certificate chain for the alias.  This takes time, so do not call from main thread.
+	 * @throws KeyChainException if the alias is not authorized ({@see KeyChain.choosePrivateKeyAlias}).
+	 */
+	@Override
+	public X509Certificate[] getCertificateChain(String alias) {
+		try {
+			return KeyChain.getCertificateChain(MyApplication.context(), alias);
+		} catch (KeyChainException | InterruptedException e) {
+			throw new RuntimeException("failed to get certificate chain for " + alias); // e may contain TMI
+		}
+	}
+
+	/**
+	 * Retrieves the private key for the alias.  This takes time, so do not call from main thread.
+	 * @throws KeyChainException if the alias is not authorized ({@see KeyChain.choosePrivateKeyAlias}).
+	 */
+	@Override
+	public PrivateKey getPrivateKey(String alias) {
+		try {
+			return KeyChain.getPrivateKey(MyApplication.context(), alias);
+		} catch (KeyChainException | InterruptedException e) {
+			throw new RuntimeException("failed to get private key for " + alias); // e may contain TMI
+		}
+	}
+
+	/** Unsupported, should never be called. */
+	@Override public String[] getClientAliases(String s, Principal[] principals) { throw new UnsupportedOperationException("should never be called"); }
+
+	/** Unsupported, should never be called. */
+	@Override public String[] getServerAliases(String s, Principal[] principals) { throw new UnsupportedOperationException("should never be called"); }
+
+	/** Unsupported, should never be called. */
+	@Override public String chooseServerAlias(String s, Principal[] principals, Socket socket) { throw new UnsupportedOperationException("should never be called"); }
+}

--- a/ttrssreader/src/main/res/values-es/strings.xml
+++ b/ttrssreader/src/main/res/values-es/strings.xml
@@ -78,6 +78,8 @@
 	<string name="ConnectionKeystorePasswordPreferenceSummary">Password to unlock custom keystore</string>
 	<string name="ConnectionUseKeystorePreferenceTitle">Custom Keystore</string>
 	<string name="ConnectionUseKeystorePreferenceSummary">Use custom keystore</string>
+	<string name="ConnectionClientCertificatePreferenceTitle">Certificado Cliente</string>
+	<string name="ConnectionClientCertificatePreferenceSummary">Presente certificado cliente si se solicita</string>
 	<string name="ConnectionHttpPreferenceCategoryTitle">Ajustes de autentificación HTTP</string>
 	<string name="ConnectionHttpPreferenceTitle">Autentificación HTTP</string>
 	<string name="ConnectionHttpPreferenceSummary">Usar autentificación HTTP</string>

--- a/ttrssreader/src/main/res/values-fr/strings.xml
+++ b/ttrssreader/src/main/res/values-fr/strings.xml
@@ -69,6 +69,8 @@
 	<string name="ConnectionKeystorePasswordPreferenceSummary">Mot de passe pour dévérouiller le certificat personnel</string>
 	<string name="ConnectionUseKeystorePreferenceTitle">Certificat personnel</string>
 	<string name="ConnectionUseKeystorePreferenceSummary">Utiliser un certificat personnel</string>
+	<string name="ConnectionClientCertificatePreferenceTitle">Certificat client</string>
+	<string name="ConnectionClientCertificatePreferenceSummary">Présenter le certificat client si demandé</string>
 	<string name="ConnectionHttpPreferenceCategoryTitle">Paramètres d\'authentification HTTP</string>
 	<string name="ConnectionHttpPreferenceTitle">Authentification HTTP</string>
 	<string name="ConnectionHttpPreferenceSummary">Utiliser l\'authentification HTTP</string>

--- a/ttrssreader/src/main/res/values/strings.xml
+++ b/ttrssreader/src/main/res/values/strings.xml
@@ -116,6 +116,8 @@
 	<string name="ConnectionKeystorePasswordPreferenceSummary">Password to unlock custom keystore</string>
 	<string name="ConnectionUseKeystorePreferenceTitle">Custom Keystore</string>
 	<string name="ConnectionUseKeystorePreferenceSummary">Use custom keystore</string>
+	<string name="ConnectionClientCertificatePreferenceTitle">Client Certificate</string>
+	<string name="ConnectionClientCertificatePreferenceSummary">Present client certificate if requested</string>
 	<string name="ConnectionHttpPreferenceCategoryTitle">HTTP-Authentication Settings</string>
 	<string name="ConnectionHttpPreferenceTitle">HTTP-Authentication</string>
 	<string name="ConnectionHttpPreferenceSummary">Use HTTP-Authentication</string>

--- a/ttrssreader/src/main/res/xml/prefs_ssl.xml
+++ b/ttrssreader/src/main/res/xml/prefs_ssl.xml
@@ -54,6 +54,12 @@
 			android:key="ConnectionKeystorePasswordPreference"
 			android:summary="@string/ConnectionKeystorePasswordPreferenceSummary"
 			android:title="@string/ConnectionKeystorePasswordPreferenceTitle" />
+		<org.ttrssreader.preferences.CertificatePreference
+			android:key="ConnectionClientCertificatePreference"
+			android:defaultValue=""
+			android:singleLine="true"
+			android:title="@string/ConnectionClientCertificatePreferenceTitle"
+			android:summary="@string/ConnectionClientCertificatePreferenceSummary"/>
 	</PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
Added new preference SSL Settings->Client Certificate.  It invokes the android certificate selection dialog, not an app-specific one.  This is necessary to authorize the app to use a cert from the central store.  The dialog may vary by device, but you should be able to add certs from either there or in the device settings (typically you need to store a .p12 file in the phone / directory).

I've tested that Apache can be configured to require this cert, and that ttrss can then be configured to use the cert as login.
