### PR TITLE
Download feed icons and display them in feed list. Fixes #241

### DIFF
--- a/ttrssreader/src/main/java/org/ttrssreader/controllers/Controller.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/controllers/Controller.java
@@ -342,13 +342,16 @@ public class Controller extends Constants implements OnSharedPreferenceChangeLis
 		return new URL(hostname());
 	}
 
-	public String hostname() {
-		// Load from Wifi-Preferences:
-		String key = getStringWithSSID(URL, getCurrentSSID(wifiManager), wifibasedPrefsEnabled());
+	public URL feedIconUrl(int feedId) throws MalformedURLException {
+		return new URL(base() + baseFeedIconPath() + "/" + feedId + ".ico");
+	}
 
-		String url;
-		if (prefs.contains(key)) url = prefs.getString(key, URL_DEFAULT);
-		else url = prefs.getString(URL, URL_DEFAULT);
+	public URL baseUrl() throws MalformedURLException {
+		return new URL(base());
+	}
+
+	public String hostname() {
+		String url = base();
 
 		if (!url.endsWith(JSON_END_URL)) {
 			if (!url.endsWith("/")) {
@@ -356,6 +359,17 @@ public class Controller extends Constants implements OnSharedPreferenceChangeLis
 			}
 			url += JSON_END_URL;
 		}
+
+		return url;
+	}
+
+	private String base() {
+		// Load from Wifi-Preferences:
+		String key = getStringWithSSID(URL, getCurrentSSID(wifiManager), wifibasedPrefsEnabled());
+
+		String url;
+		if (prefs.contains(key)) url = prefs.getString(key, URL_DEFAULT);
+		else url = prefs.getString(URL, URL_DEFAULT);
 
 		return url;
 	}
@@ -387,6 +401,16 @@ public class Controller extends Constants implements OnSharedPreferenceChangeLis
 			useOfALazyServer = prefs.getBoolean(USE_OF_A_LAZY_SERVER, Constants.USE_OF_A_LAZY_SERVER_DEFAULT);
 
 		return useOfALazyServer;
+	}
+
+	public String baseFeedIconPath() {
+		// Load from Wifi-Preferences:
+		String key = getStringWithSSID(URL_FEEDICONS, getCurrentSSID(wifiManager), wifibasedPrefsEnabled());
+
+		String url;
+		if (prefs.contains(key)) url = prefs.getString(key, URL_DEFAULT_FEEDICONS);
+		else url = prefs.getString(URL_FEEDICONS, URL_DEFAULT_FEEDICONS);
+		return url;
 	}
 
 	public boolean useProxy() {

--- a/ttrssreader/src/main/java/org/ttrssreader/controllers/Data.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/controllers/Data.java
@@ -34,6 +34,8 @@ import org.ttrssreader.net.IdUpdatedArticleOmitter;
 import org.ttrssreader.net.JSONConnector;
 import org.ttrssreader.utils.Utils;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -154,6 +156,26 @@ public class Data {
 			DBHelper.getInstance().markArticles(articleUnreadIds, "isUnread", 1);
 		}
 		Log.d(TAG, "cacheArticles() Took: " + (System.currentTimeMillis() - timeStart) + "ms");
+	}
+
+	/**
+	 * Downloads the favicon for the given feed ID and inserts it into the database.
+	 *
+	 * @param feedId ID of the feed
+	 */
+	public void updateFeedIcon(int feedId) {
+		Log.d(TAG, "Updating icon for feed #" + feedId);
+		try {
+			byte[] icon = downloadFeedIcon(feedId);
+			DBHelper.getInstance().insertFeedIcon(feedId, icon);
+		} catch (MalformedURLException e) {
+			Log.e(TAG, "Error while downloading icon for feed #" + feedId, e);
+		}
+	}
+
+	public byte[] downloadFeedIcon(int feedId) throws MalformedURLException {
+		final URL iconUrl = Controller.getInstance().feedIconUrl(feedId);
+		return Utils.download(iconUrl);
 	}
 
 	/**

--- a/ttrssreader/src/main/java/org/ttrssreader/gui/CategoryActivity.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/gui/CategoryActivity.java
@@ -17,7 +17,6 @@
 
 package org.ttrssreader.gui;
 
-
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.content.Context;
@@ -255,6 +254,7 @@ public class CategoryActivity extends MenuActivity implements IItemSelectedListe
 			// Refresh articles for all labels
 			for (Feed f : labels) {
 				Data.getInstance().updateArticles(f.id, false, false, false, forceUpdate);
+				Data.getInstance().updateFeedIcon(f.id);
 				publishProgress(++progress);
 			}
 

--- a/ttrssreader/src/main/java/org/ttrssreader/gui/FeedHeadlineActivity.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/gui/FeedHeadlineActivity.java
@@ -17,6 +17,14 @@
 
 package org.ttrssreader.gui;
 
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.widget.Toast;
 
 import org.ttrssreader.R;
 import org.ttrssreader.controllers.Controller;
@@ -27,15 +35,6 @@ import org.ttrssreader.gui.fragments.FeedListFragment;
 import org.ttrssreader.gui.fragments.MainListFragment;
 import org.ttrssreader.utils.AsyncTask;
 import org.ttrssreader.utils.Utils;
-
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
-import android.os.Bundle;
-import android.util.Log;
-import android.view.KeyEvent;
-import android.view.Menu;
-import android.view.MenuItem;
-import android.widget.Toast;
 
 import java.util.List;
 
@@ -284,6 +283,7 @@ public class FeedHeadlineActivity extends MenuActivity {
 				Data.getInstance().updateArticles(categoryId, displayUnread, true, false, forceUpdate);
 			} else {
 				Data.getInstance().updateArticles(feedId, displayUnread, false, false, forceUpdate);
+				Data.getInstance().updateFeedIcon(feedId);
 			}
 			publishProgress(++progress);
 

--- a/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/FeedHeadlineListFragment.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/FeedHeadlineListFragment.java
@@ -17,6 +17,26 @@
 
 package org.ttrssreader.gui.fragments;
 
+import android.app.Activity;
+import android.content.Context;
+import android.content.CursorLoader;
+import android.content.Intent;
+import android.content.Loader;
+import android.database.Cursor;
+import android.net.Uri;
+import android.net.Uri.Builder;
+import android.os.Bundle;
+import android.support.v7.app.ActionBar;
+import android.view.ContextMenu;
+import android.view.GestureDetector;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.WindowManager;
+import android.widget.AdapterView;
+import android.widget.AdapterView.AdapterContextMenuInfo;
+
 import org.ttrssreader.R;
 import org.ttrssreader.controllers.Controller;
 import org.ttrssreader.controllers.DBHelper;
@@ -42,26 +62,6 @@ import org.ttrssreader.model.updaters.StarredStateUpdater;
 import org.ttrssreader.model.updaters.UnsubscribeUpdater;
 import org.ttrssreader.model.updaters.Updater;
 import org.ttrssreader.utils.AsyncTask;
-
-import android.app.Activity;
-import android.content.Context;
-import android.content.CursorLoader;
-import android.content.Intent;
-import android.content.Loader;
-import android.database.Cursor;
-import android.net.Uri;
-import android.net.Uri.Builder;
-import android.os.Bundle;
-import android.support.v7.app.ActionBar;
-import android.view.ContextMenu;
-import android.view.GestureDetector;
-import android.view.Menu;
-import android.view.MenuItem;
-import android.view.MotionEvent;
-import android.view.View;
-import android.view.WindowManager;
-import android.widget.AdapterView;
-import android.widget.AdapterView.AdapterContextMenuInfo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -365,7 +365,10 @@ public class FeedHeadlineListFragment extends MainListFragment implements TextIn
 			if (category != null) title = category.title;
 		} else {
 			Feed feed = DBHelper.getInstance().getFeed(feedId);
-			if (feed != null) title = feed.title;
+			if (feed != null) {
+				title = feed.title;
+				if(feed.icon != null) icon = feed.icon;
+			}
 		}
 		unreadCount = DBHelper.getInstance()
 				.getUnreadCount(selectArticlesForCategory ? categoryId : feedId, selectArticlesForCategory);

--- a/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/MainListFragment.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/MainListFragment.java
@@ -17,17 +17,6 @@
 
 package org.ttrssreader.gui.fragments;
 
-
-import org.ttrssreader.R;
-import org.ttrssreader.controllers.Controller;
-import org.ttrssreader.gui.MenuActivity;
-import org.ttrssreader.gui.interfaces.IDataChangedListener;
-import org.ttrssreader.gui.interfaces.IItemSelectedListener;
-import org.ttrssreader.gui.interfaces.IItemSelectedListener.TYPE;
-import org.ttrssreader.gui.view.MyGestureDetector;
-import org.ttrssreader.model.MainAdapter;
-import org.ttrssreader.utils.AsyncTask;
-
 import android.animation.Animator;
 import android.animation.AnimatorInflater;
 import android.app.Activity;
@@ -47,6 +36,16 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ListView;
+
+import org.ttrssreader.R;
+import org.ttrssreader.controllers.Controller;
+import org.ttrssreader.gui.MenuActivity;
+import org.ttrssreader.gui.interfaces.IDataChangedListener;
+import org.ttrssreader.gui.interfaces.IItemSelectedListener;
+import org.ttrssreader.gui.interfaces.IItemSelectedListener.TYPE;
+import org.ttrssreader.gui.view.MyGestureDetector;
+import org.ttrssreader.model.MainAdapter;
+import org.ttrssreader.utils.AsyncTask;
 
 public abstract class MainListFragment extends ListFragment implements LoaderManager.LoaderCallbacks<Cursor> {
 
@@ -69,6 +68,7 @@ public abstract class MainListFragment extends ListFragment implements LoaderMan
 
 	protected String title;
 	protected int unreadCount;
+	protected byte[] icon;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {

--- a/ttrssreader/src/main/java/org/ttrssreader/imageCache/ImageCacher.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/imageCache/ImageCacher.java
@@ -189,6 +189,7 @@ class ImageCacher extends AsyncTask<Void, Integer, Void> {
 				publishProgress(++progress);
 				if (checkCancelRequested()) return;
 				Data.getInstance().updateArticles(f.id, true, false, false, true);
+				Data.getInstance().updateFeedIcon(f.id);
 			}
 
 			Data.getInstance().calculateCounters();

--- a/ttrssreader/src/main/java/org/ttrssreader/model/FeedAdapter.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/model/FeedAdapter.java
@@ -17,10 +17,10 @@
 
 package org.ttrssreader.model;
 
-
 import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Typeface;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -97,6 +97,12 @@ public class FeedAdapter extends MainAdapter {
 		ret.id = cur.getInt(0);
 		ret.title = cur.getString(1);
 		ret.unread = cur.getInt(2);
+		if(!cur.isNull(3)) {
+			Log.d(TAG, "Icon found for feed " + ret.title);
+			ret.icon = cur.getBlob(3);
+		} else {
+			Log.d(TAG, "No icon found for feed " + ret.title);
+		}
 		return ret;
 	}
 

--- a/ttrssreader/src/main/java/org/ttrssreader/model/FeedCursorHelper.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/model/FeedCursorHelper.java
@@ -17,12 +17,12 @@
 
 package org.ttrssreader.model;
 
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
 import org.ttrssreader.controllers.Controller;
 import org.ttrssreader.controllers.DBHelper;
 import org.ttrssreader.utils.Utils;
-
-import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
 
 class FeedCursorHelper extends MainCursorHelper {
 
@@ -50,7 +50,7 @@ class FeedCursorHelper extends MainCursorHelper {
 			query.append("SELECT _id,title,unread FROM (");
 		}
 
-		query.append("SELECT _id,title,unread FROM ");
+		query.append("SELECT _id,title,unread,icon FROM ");
 		query.append(DBHelper.TABLE_FEEDS);
 		query.append(" WHERE categoryId=");
 		query.append(categoryId);

--- a/ttrssreader/src/main/java/org/ttrssreader/model/FeedHeadlineAdapter.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/model/FeedHeadlineAdapter.java
@@ -17,9 +17,9 @@
 
 package org.ttrssreader.model;
 
-
 import android.content.Context;
 import android.database.Cursor;
+import android.graphics.BitmapFactory;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.view.View;
@@ -28,7 +28,9 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.ttrssreader.R;
+import org.ttrssreader.controllers.DBHelper;
 import org.ttrssreader.model.pojos.Article;
+import org.ttrssreader.model.pojos.Feed;
 import org.ttrssreader.utils.DateUtils;
 
 import java.util.Date;
@@ -89,6 +91,12 @@ public class FeedHeadlineAdapter extends MainAdapter {
 		}
 	}
 
+	private static void setFeedImage(ImageView icon, Feed f) {
+		if(f.icon != null) {
+			icon.setImageBitmap(BitmapFactory.decodeByteArray(f.icon, 0, f.icon.length));
+		}
+	}
+
 	@Override
 	public View newView(Context context, Cursor cursor, ViewGroup parent) {
 		return View.inflate(context, R.layout.item_feedheadline, null);
@@ -102,6 +110,7 @@ public class FeedHeadlineAdapter extends MainAdapter {
 		if (holder == null) {
 			holder = new ViewHolder();
 			holder.icon = (ImageView) view.findViewById(R.id.icon);
+			holder.feedicon = (ImageView) view.findViewById(R.id.feedicon);
 			holder.title = (TextView) view.findViewById(R.id.title);
 			holder.updateDate = (TextView) view.findViewById(R.id.updateDate);
 			holder.dataSource = (TextView) view.findViewById(R.id.dataSource);
@@ -109,8 +118,10 @@ public class FeedHeadlineAdapter extends MainAdapter {
 		}
 
 		final Article a = getArticle(cursor);
+		final Feed f = DBHelper.getInstance().getFeed(a.feedId);
 
 		setImage(holder.icon, a);
+		setFeedImage(holder.feedicon, f);
 
 		holder.title.setText(a.title);
 		if (a.isUnread) holder.title.setTypeface(Typeface.DEFAULT_BOLD);
@@ -142,6 +153,7 @@ public class FeedHeadlineAdapter extends MainAdapter {
 	private static class ViewHolder {
 		TextView title;
 		ImageView icon;
+		ImageView feedicon;
 		TextView updateDate;
 		TextView dataSource;
 	}

--- a/ttrssreader/src/main/java/org/ttrssreader/model/pojos/Feed.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/model/pojos/Feed.java
@@ -26,6 +26,7 @@ public class Feed implements Comparable<Feed> {
 	public String title;
 	public String url;
 	public int unread;
+	public byte[] icon;
 
 	@Override
 	public int compareTo(Feed fi) {

--- a/ttrssreader/src/main/java/org/ttrssreader/net/JSONConnector.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/net/JSONConnector.java
@@ -831,6 +831,7 @@ public class JSONConnector {
 	private Set<Feed> getFeeds(boolean tolerateWrongUnreadInformation) {
 		long time = System.currentTimeMillis();
 		Set<Feed> ret = new LinkedHashSet<>();
+		Map<Integer, byte[]> iconsPerFeed = new HashMap<>();
 		if (sessionNotAlive()) return ret;
 
 		if (!tolerateWrongUnreadInformation) {
@@ -864,6 +865,11 @@ public class JSONConnector {
 						switch (reader.nextName()) {
 							case ID:
 								id = reader.nextInt();
+								// download only once
+								if(!iconsPerFeed.containsKey(id)) {
+									byte[] icon = Data.getInstance().downloadFeedIcon(id);
+									iconsPerFeed.put(id, icon);
+								}
 								break;
 							case CAT_ID:
 								categoryId = reader.nextInt();
@@ -882,7 +888,7 @@ public class JSONConnector {
 								break;
 						}
 					} catch (IllegalArgumentException e) {
-						e.printStackTrace();
+						Log.e(TAG, e.getMessage());
 						reader.skipValue();
 					}
 
@@ -897,6 +903,7 @@ public class JSONConnector {
 						f.title = title;
 						f.url = feedUrl;
 						f.unread = unread;
+						f.icon = iconsPerFeed.containsKey(id) ? iconsPerFeed.get(id) : null;
 						ret.add(f);
 					}
 				}
@@ -904,7 +911,7 @@ public class JSONConnector {
 			}
 			reader.endArray();
 		} catch (IOException e) {
-			e.printStackTrace();
+			Log.e(TAG, e.getMessage());
 		} finally {
 			if (reader != null) try {
 				reader.close();

--- a/ttrssreader/src/main/java/org/ttrssreader/preferences/Constants.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/preferences/Constants.java
@@ -31,6 +31,7 @@ public class Constants {
 
 	// Connection
 	public static final String URL = "ConnectionUrlPreference";
+	public static final String URL_FEEDICONS = "ConnectionUrlFeedIconsPreference";
 	public static final String USERNAME = "ConnectionUsernamePreference";
 	public static final String PASSWORD = "ConnectionPasswordPreference";
 	public static final String USE_HTTP_AUTH = "ConnectionHttpPreference";
@@ -50,6 +51,7 @@ public class Constants {
 
 	// Connection Default Values
 	public static final String URL_DEFAULT = "https://localhost/";
+	public static final String URL_DEFAULT_FEEDICONS = "feed-icons";
 	public static final boolean USE_HTTP_AUTH_DEFAULT = false;
 	public static final boolean USE_PROVIDER_INSTALLER_DEFAULT = true;
 	public static final boolean TRUST_ALL_SSL_DEFAULT = false;

--- a/ttrssreader/src/main/java/org/ttrssreader/utils/Utils.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/utils/Utils.java
@@ -46,13 +46,17 @@ import org.ttrssreader.R;
 import org.ttrssreader.controllers.Controller;
 import org.ttrssreader.preferences.Constants;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -471,4 +475,40 @@ public class Utils {
 		}
 	}
 
+	/**
+	 * Downloads the given URL and returns the body as an <code>byte[]</code>.
+	 * @param url URL to download
+	 * @return content as <code>byte[]</code>
+	 */
+	public static byte[] download(URL url) {
+		ByteArrayOutputStream output = new ByteArrayOutputStream();
+		try {
+			URLConnection connection = Controller.getInstance().openConnection(url);
+			connection.connect();
+
+			// download the file
+			InputStream input = new BufferedInputStream(url.openStream(), 8192);
+
+			byte data[] = new byte[1024];
+			int count = -1;
+			while ((count = input.read(data)) != -1) {
+				// writing data to file
+				output.write(data, 0, count);
+			}
+
+			// closing streams
+			output.close();
+			input.close();
+
+		} catch (Exception e) {
+			Log.e(TAG, "Error while downloading feed icon: " + e.getMessage());
+		}
+
+		if(output.size() != 0) {
+			Log.d(TAG, "Downloaded " + output.size() + " bytes as feed icon from " + url.toExternalForm());
+			return output.toByteArray();
+		} else {
+			return null;
+		}
+	}
 }

--- a/ttrssreader/src/main/res/layout/item_feedheadline.xml
+++ b/ttrssreader/src/main/res/layout/item_feedheadline.xml
@@ -42,17 +42,25 @@
 			android:layout_height="wrap_content"
 			android:orientation="horizontal">
 
+			<ImageView
+				android:id="@+id/feedicon"
+				android:gravity="start"
+				android:layout_marginRight="10dp"
+				android:layout_width="12sp"
+				android:layout_height="12sp"
+				android:contentDescription="@string/Empty"
+				/>
+
 			<TextView
 				android:id="@+id/updateDate"
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
-				android:gravity="start"
 				android:textIsSelectable="false"
 				android:textSize="12sp" />
 
 			<TextView
 				android:id="@+id/dataSource"
-				android:layout_width="match_parent"
+				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
 				android:layout_marginRight="10dp"
 				android:layout_marginEnd="10dp"

--- a/ttrssreader/src/main/res/values/strings.xml
+++ b/ttrssreader/src/main/res/values/strings.xml
@@ -131,6 +131,9 @@
 	<string name="ConnectionHttpUsernamePreferenceTitle">Username</string>
 	<string name="ConnectionHttpPasswordPreferenceTitle">Password</string>
 	<string name="ConnectionHttpPasswordPreferenceSummary">The password for your HTTP-based authentication method</string>
+	<string name="ConnectionFeedIconsUrlPreferenceTitle">Feed Icons path</string>
+	<string name="ConnectionFeedIconsUrlPreferenceSummary">The base URL path to the feed icons</string>
+	<string name="ConnectionFeedIconsUrlPreferenceDefault">feed-icons</string>
 	<string name="MiscellaneousPreferenceCategoryTitle">Miscellaneous Preferences</string>
 	<string name="UsagePreferenceCategoryTitle">Usage</string>
 	<string name="UsageOpenUrlEmptyArticleTitle">Open URL for empty article</string>

--- a/ttrssreader/src/main/res/xml/prefs_main_top.xml
+++ b/ttrssreader/src/main/res/xml/prefs_main_top.xml
@@ -45,11 +45,19 @@
 			android:order="30"
 			android:summary="@string/ConnectionPasswordPreferenceSummary"
 			android:title="@string/ConnectionPasswordPreferenceTitle" />
+		<EditTextPreference
+			android:name="@string/ConnectionFeedIconsUrlPreferenceTitle"
+			android:defaultValue="@string/ConnectionFeedIconsUrlPreferenceDefault"
+			android:inputType="textFilter"
+			android:key="ConnectionFeedIconsUrlPreference"
+			android:order="40"
+			android:summary="@string/ConnectionFeedIconsUrlPreferenceSummary"
+			android:title="@string/ConnectionFeedIconsUrlPreferenceTitle" />
 
 		<CheckBoxPreference
 			android:defaultValue="false"
 			android:key="ConnectionLazyServerPreference"
-			android:order="40"
+			android:order="50"
 			android:summary="@string/ConnectionLazyServerPreferenceSummary"
 			android:title="@string/ConnectionLazyServerPreferenceTitle" />
 


### PR DESCRIPTION
Feed icons are downloaded from ttrss and displayed in the feed item list 
now. The URL path to feed icons can be set via Preferences, getting it from
the server config is not implemented. This can be improved, but I was
not clear about when to update the value and I didn't want to fetch it
for every request to the server or something similar naive.

The feed icon is displayed in the 2nd line of the feed item list, on
the right of the item date. The layout is not nice and centered, but I
had to give up on the Android layout... 😞 If there are any improvements
I could do, please let me know and I'll update the PR.

I noticed some of the imports were changed too, and I tried to figure out 
what the usual ordering is, but I am not sure if I did this right. I ordered 
`android.*` at the top, which seems the case for many of the files. Please let
me know if I should re-order them.