### PR TITLE
Reduce startup latency by re-using OkHttp client

### DIFF
--- a/ttrssreader/src/main/java/org/ttrssreader/net/JSONConnector.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/net/JSONConnector.java
@@ -152,6 +152,19 @@ public class JSONConnector {
 
 	public static final int PARAM_LIMIT_MAX_VALUE = 200;
 
+	private OkHttpClient client;
+
+	public JSONConnector() {
+		// Set longer timeouts for lazy loading servers
+		TimeUnit timeoutUnit = Controller.getInstance().lazyServer() ? TimeUnit.MINUTES : TimeUnit.SECONDS;
+
+		// Build Client-Object:
+		OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
+		clientBuilder.proxy(getProxy());
+		clientBuilder.readTimeout(10, timeoutUnit);
+		this.client = clientBuilder.build();
+	}
+
 	private Reader doRequest(Map<String, String> params) {
 		try {
 			if (sessionId != null)
@@ -159,9 +172,6 @@ public class JSONConnector {
 
 			JSONObject json = new JSONObject(params);
 			logRequest(json);
-
-			// Set longer timeouts for lazy loading servers
-			TimeUnit timeoutUnit = Controller.getInstance().lazyServer() ? TimeUnit.MINUTES : TimeUnit.SECONDS;
 
 			// Build Request-Object:
 			Request.Builder reqBuilder = new Request.Builder();
@@ -177,14 +187,8 @@ public class JSONConnector {
 
 			Request request = reqBuilder.build();
 
-			// Build Client-Object:
-			OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
-			clientBuilder.proxy(getProxy());
-			clientBuilder.readTimeout(10, timeoutUnit);
-			OkHttpClient client = clientBuilder.build();
-
 			// Call Server:
-			Response response = client.newCall(request).execute();
+			Response response = this.client.newCall(request).execute();
 
 			// Check for HTTP Status codes:
 			int code = response.code();


### PR DESCRIPTION
Before this patch:
```
09-06 00:53:21.707  18649    18670          JSONConnector  D  internalLogin: 1071ms
09-06 00:53:22.647  18649    18670          JSONConnector  D  getHeadlines: 2011ms
09-06 00:53:23.664  18649    18670          JSONConnector  D  getHeadlines: 1012ms
09-06 00:53:24.688  18649    18670          JSONConnector  D  getCategories: 984ms
09-06 00:53:25.768  18649    18670          JSONConnector  D  getFeeds: 1072ms
```
After this patch:
```
09-06 00:52:58.534  18415    18436          JSONConnector  D  internalLogin: 1135ms
09-06 00:52:58.854  18415    18436          JSONConnector  D  getHeadlines: 1455ms
09-06 00:52:59.149  18415    18436          JSONConnector  D  getHeadlines: 291ms
09-06 00:52:59.458  18415    18436          JSONConnector  D  getCategories: 274ms
09-06 00:52:59.805  18415    18436          JSONConnector  D  getFeeds: 338ms
```
43% reduction in terms of latency :smiley: 

Ping latency for my server: ~160ms. I use TLS 1.3 + HTTP/2 on Apache.