### PR TITLE
Swiping left to right on an article toggles its read state

### DIFF
--- a/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/MainListFragment.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/MainListFragment.java
@@ -36,7 +36,7 @@ import org.ttrssreader.controllers.Controller;
 import org.ttrssreader.gui.interfaces.IDataChangedListener;
 import org.ttrssreader.gui.interfaces.IItemSelectedListener;
 import org.ttrssreader.gui.interfaces.IItemSelectedListener.TYPE;
-import org.ttrssreader.gui.view.MyGestureDetector;
+import org.ttrssreader.gui.view.MyGestureListener;
 import org.ttrssreader.model.MainAdapter;
 import org.ttrssreader.utils.AsyncTask;
 
@@ -117,9 +117,10 @@ public abstract class MainListFragment extends ListFragment implements LoaderMan
 		if (activity != null) {
 			ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
 
-			gestureDetector = new GestureDetector(getActivity(), new MyGestureDetector(actionBar, Controller.getInstance().hideActionbar()), null);
-			gestureListener = (v, event) -> gestureDetector.onTouchEvent(event) || v.performClick();
-			getListView().setOnTouchListener(gestureListener);
+			MyGestureListener gestureListener = new MyGestureListener(actionBar, Controller.getInstance().hideActionbar(), getActivity());
+			gestureDetector = new GestureDetector(getActivity(), gestureListener, null);
+			this.gestureListener = (v, event) -> gestureDetector.onTouchEvent(event) || v.performClick();
+			getListView().setOnTouchListener(this.gestureListener);
 		}
 
 		// Read the selected list item after orientation changes and similar

--- a/ttrssreader/src/main/java/org/ttrssreader/gui/view/MyGestureListener.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/gui/view/MyGestureListener.java
@@ -17,25 +17,42 @@
 
 package org.ttrssreader.gui.view;
 
+import android.app.Activity;
+import android.content.Context;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 
+import android.view.WindowManager;
 import org.ttrssreader.controllers.Controller;
 
 import androidx.appcompat.app.ActionBar;
 
-public class MyGestureDetector extends GestureDetector.SimpleOnGestureListener {
+public class MyGestureListener extends GestureDetector.SimpleOnGestureListener {
 
 	@SuppressWarnings("unused")
-	private static final String TAG = MyGestureDetector.class.getSimpleName();
+	private static final String TAG = MyGestureListener.class.getSimpleName();
 
 	private ActionBar actionBar;
 	private boolean hideActionbar;
 	private long lastShow = -1;
+	private Activity activity;
 
-	public MyGestureDetector(ActionBar actionBar, boolean hideActionbar) {
+	public MyGestureListener(ActionBar actionBar, boolean hideActionbar, Activity activity) {
 		this.actionBar = actionBar;
 		this.hideActionbar = hideActionbar;
+		this.activity = activity;
+	}
+
+	@Override
+	public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+		// Refresh metrics-data in Controller
+		if (activity != null) {
+			WindowManager wm = ((WindowManager) activity.getSystemService(Context.WINDOW_SERVICE));
+			if (wm != null)
+				Controller.refreshDisplayMetrics(wm.getDefaultDisplay());
+		}
+
+		return super.onFling(e1, e2, velocityX, velocityY);
 	}
 
 	@Override
@@ -62,5 +79,4 @@ public class MyGestureDetector extends GestureDetector.SimpleOnGestureListener {
 
 		return false;
 	}
-
 }

--- a/ttrssreader/src/main/java/org/ttrssreader/gui/view/SwipeGestureListener.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/gui/view/SwipeGestureListener.java
@@ -1,0 +1,23 @@
+package org.ttrssreader.gui.view;
+
+import android.app.Activity;
+import android.view.MotionEvent;
+import androidx.appcompat.app.ActionBar;
+import org.ttrssreader.controllers.Controller;
+
+public abstract class SwipeGestureListener extends MyGestureListener {
+    protected SwipeGestureListener(ActionBar actionBar, boolean hideActionbar, Activity activity) {
+        super(actionBar, hideActionbar, activity);
+    }
+
+    @Override
+    public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+        if (Math.abs(e1.getX() - e2.getX()) > Controller.relSwipeMinDistance && Math.abs(velocityX) > Controller.relSwipeThresholdVelocity) {
+            return onSwipe(e1, e2, velocityX, velocityY);
+        } else {
+            return super.onFling(e1, e2, velocityX, velocityY);
+        }
+    }
+
+    public abstract boolean onSwipe(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY);
+}


### PR DESCRIPTION
This implements #275

Refactored custom gesture listeners a bit.
When a left-to-right swipe is performed on an article headline in a list, toggles article read state.

Currently this precludes any other behavior, that existed before this change.

I did not test the new swipe handler on anything but articles. Can happily do that if somebody can point me to test steps for feed navigation.