### PR TITLE
Added an option to show Mark Read/Unread button instead of Publish

### DIFF
--- a/ttrssreader/src/main/java/org/ttrssreader/controllers/Controller.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/controllers/Controller.java
@@ -131,6 +131,7 @@ public class Controller extends Constants implements OnSharedPreferenceChangeLis
 	private Boolean invertSortArticlelist = null;
 	private Boolean invertSortFeedscats = null;
 	private Boolean alignFlushLeft = null;
+	private Boolean preferMarkReadOverPublish = null;
 	private Boolean dateTimeSystem = null;
 	private String dateString = null;
 	private String timeString = null;
@@ -989,6 +990,17 @@ public class Controller extends Constants implements OnSharedPreferenceChangeLis
 	public void setAlignFlushLeft(boolean alignFlushLeft) {
 		put(ALIGN_FLUSH_LEFT, alignFlushLeft);
 		this.alignFlushLeft = alignFlushLeft;
+	}
+
+	public boolean preferMarkReadOverPublish(){
+		if (preferMarkReadOverPublish == null)
+			preferMarkReadOverPublish = prefs.getBoolean(PREFER_MARK_READ_OVER_PUBLISH, false);
+		return preferMarkReadOverPublish;
+	}
+
+	public void setPreferMarkReadOverPublish(boolean preferMarkReadOverPublish){
+		put(PREFER_MARK_READ_OVER_PUBLISH, preferMarkReadOverPublish);
+		this.preferMarkReadOverPublish = preferMarkReadOverPublish;
 	}
 
 	public boolean dateTimeSystem() {

--- a/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/ArticleFragment.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/ArticleFragment.java
@@ -618,6 +618,11 @@ public class ArticleFragment extends Fragment implements TextInputAlertCallback 
 			}
 		}
 
+		if (Controller.getInstance().preferMarkReadOverPublish()) {
+			read.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+			publish.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM | MenuItem.SHOW_AS_ACTION_WITH_TEXT);
+		}
+
 		MenuItem star = menu.findItem(R.id.Article_Menu_MarkStar);
 		if (star != null) {
 			if (article.isStarred) {

--- a/ttrssreader/src/main/java/org/ttrssreader/preferences/Constants.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/preferences/Constants.java
@@ -103,6 +103,7 @@ public class Constants {
 	public static final String INVERT_SORT_ARTICLELIST = "InvertSortArticlelistPreference";
 	public static final String INVERT_SORT_FEEDSCATS = "InvertSortFeedscatsPreference";
 	public static final String ALIGN_FLUSH_LEFT = "DisplayAlignFlushLeftPreference";
+	public static final String PREFER_MARK_READ_OVER_PUBLISH = "PreferMarkReadOverPublish";
 	public static final String DATE_TIME_SYSTEM = "DisplayDateTimeFormatSystemPreference";
 	public static final String DATE_STRING = "DisplayDateFormatPreference";
 	public static final String TIME_STRING = "DisplayTimeFormatPreference";

--- a/ttrssreader/src/main/res/values/strings.xml
+++ b/ttrssreader/src/main/res/values/strings.xml
@@ -149,6 +149,8 @@
     <string name="UsageOfflineTitle">Work offline</string>
     <string name="UsageOnlineTitle">Work online</string>
     <string name="DisplayPreferenceCategoryTitle">Display</string>
+    <string name="DisplayMarkReadInsteadOfPublishTitle">Prefer \"Mark Unread\" over \"Publish\"</string>
+    <string name="DisplayMarkReadInsteadOfPublishSummary">Always show \"Mark Unread\" instead of \"Publish\" button</string>
     <string name="DisplayVirtualPreferenceTitle">Show virtual feeds</string>
     <string name="DisplayVirtualPreferenceSummary">Uncheck to hide TTRSS virtual feeds.</string>
     <string name="DisplayLoadImagesPreferenceTitle">Load media</string>

--- a/ttrssreader/src/main/res/xml/prefs_usage.xml
+++ b/ttrssreader/src/main/res/xml/prefs_usage.xml
@@ -59,6 +59,11 @@
             android:summary="@string/GoBackAfterMarkAllReadPreferenceSummary"
             android:title="@string/GoBackAfterMarkAllReadPreferenceTitle"/>
         <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="PreferMarkReadOverPublish"
+            android:summary="@string/DisplayMarkReadInsteadOfPublishSummary"
+            android:title="@string/DisplayMarkReadInsteadOfPublishTitle" />
+        <CheckBoxPreference
             android:defaultValue="true"
             android:key="HideActionbarPreference"
             android:summary="@string/HideActionbarSummary"


### PR DESCRIPTION
I rarely publish or share any articles, but quite often decide to delay reading the article in front of me by marking it "Unread". For this scenario I'd love to have "Mark Unread" button readily available.