### PR TITLE
configure sslSocketFactory for OkHttp

### DIFF
--- a/ttrssreader/src/main/java/org/ttrssreader/net/JSONConnector.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/net/JSONConnector.java
@@ -37,6 +37,8 @@ import org.ttrssreader.model.pojos.Category;
 import org.ttrssreader.model.pojos.Feed;
 import org.ttrssreader.model.pojos.Label;
 import org.ttrssreader.preferences.Constants;
+import org.ttrssreader.utils.KeyChainKeyManager;
+import org.ttrssreader.utils.SSLUtils;
 import org.ttrssreader.utils.StringSupport;
 import org.ttrssreader.utils.Utils;
 
@@ -52,6 +54,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
 import okhttp3.Credentials;
@@ -180,6 +185,7 @@ public class JSONConnector {
 
 			// Build Client-Object:
 			OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
+			clientBuilder.sslSocketFactory(SSLUtils.factory);
 			clientBuilder.proxy(getProxy());
 			clientBuilder.readTimeout(10, timeoutUnit);
 			this.client = clientBuilder.build();

--- a/ttrssreader/src/main/java/org/ttrssreader/net/JSONConnector.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/net/JSONConnector.java
@@ -37,7 +37,6 @@ import org.ttrssreader.model.pojos.Category;
 import org.ttrssreader.model.pojos.Feed;
 import org.ttrssreader.model.pojos.Label;
 import org.ttrssreader.preferences.Constants;
-import org.ttrssreader.utils.KeyChainKeyManager;
 import org.ttrssreader.utils.SSLUtils;
 import org.ttrssreader.utils.StringSupport;
 import org.ttrssreader.utils.Utils;
@@ -54,9 +53,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
 import okhttp3.Credentials;

--- a/ttrssreader/src/main/java/org/ttrssreader/utils/SSLUtils.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/utils/SSLUtils.java
@@ -46,14 +46,13 @@ import javax.net.ssl.X509TrustManager;
 public class SSLUtils {
 
 	private static final String TAG = SSLUtils.class.getSimpleName();
+	public volatile static SSLSocketFactory factory;
 
 	public static void initSslSocketFactory(KeyManager[] km, TrustManager[] tm) throws KeyManagementException, NoSuchAlgorithmException {
 
 		SSLContext ctx = SSLContext.getInstance("TLS");
 		ctx.init(km, tm, null);
-		SSLSocketFactory factory = ctx.getSocketFactory();
-
-		HttpsURLConnection.setDefaultSSLSocketFactory(factory);
+		factory = ctx.getSocketFactory();
 	}
 
 	public static void initPrivateKeystore(String password) throws GeneralSecurityException {
@@ -134,6 +133,6 @@ public class SSLUtils {
 		KeyManager km = new KeyChainKeyManager();
 		SSLContext sslContext = SSLContext.getInstance("TLS");
 		sslContext.init(new KeyManager[]{km}, null, null);
-		HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
+		initSslSocketFactory(new KeyManager[]{km}, null);
 	}
 }


### PR DESCRIPTION
Client certificate connections have been broken for a few months now. I think it's because the config for the new OkHttp library didn't include anything to do with TLS. I've added that in this PR

In passing, I think the UI doesn't make it clear that if you select client certificate authentication, your settings for "Accept all certificates" and "Trust All Hosts" are ignored. (Unless I'm misreading the code)