### PR TITLE
Fix swiping in article view

### DIFF
--- a/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/ArticleFragment.java
+++ b/ttrssreader/src/main/java/org/ttrssreader/gui/fragments/ArticleFragment.java
@@ -969,7 +969,7 @@ public class ArticleFragment extends Fragment implements TextInputAlertCallback 
 
 		@Override
 		public boolean onSwipe(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
-			int direction = e1.getX() > e1.getY() ? 1 : -1;
+			int direction = e1.getX() > e2.getX() ? 1 : -1;
 
 			FeedHeadlineActivity fhActivity = (FeedHeadlineActivity) getActivity();
 			if (fhActivity != null)


### PR DESCRIPTION
Swiping left-to-right in the article view (i.e. when the content of an article is displayed) is supposed to move the view to the next article of the current list, and swiping right-to-left to move to the previous article.

This [update](https://github.com/nilsbraden/ttrss-reader-fork/commit/54a8ea6c574ba79f322da35cc416a18ccb9d33ab#diff-dbd5de5c44806586dd6de807f91756a2ad4949ece14d15a1d59dbe71ca827ff7R972) changes that, as the "next article vs. previous article" direction now depends on the x and y of the swiping's initial point, i.e.

- a right-to-left swiping on the top of the screen moves to the next article

- a right-to-left swiping on the bottom of the screen moves to the previous article

I propose to restore the previous behavior by comparing the x coordinates of the initial and last swiping points (as it is already done in FeedHeadlineListFragment.java)